### PR TITLE
Disable fetch if report already exists

### DIFF
--- a/reports/src/capability/useReport.tsx
+++ b/reports/src/capability/useReport.tsx
@@ -28,6 +28,7 @@ export const useReport = ({
 
   useEffect(() => {
     const fetchReport = async () => {
+      if (_report) return;
       setLoading(true);
       try {
         const res = await fetch(reportUrl);


### PR DESCRIPTION
Fixes issue with statically rendered reports
